### PR TITLE
c++11 requirement for xcode

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -34,6 +34,12 @@
         }
         ]
       ],
+      'xcode_settings': {
+        'MACOSX_DEPLOYMENT_TARGET':'10.8',
+        'CLANG_CXX_LIBRARY': 'libc++',
+        'CLANG_CXX_LANGUAGE_STANDARD':'c++11',
+        'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0'
+      },
       'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
       "cflags": [ "-include ../src/gcc-preinclude.h" ],
       "sources": [


### PR DESCRIPTION
In reference to https://github.com/mapbox/node-sqlite3/issues/830
MacOS and xcode need the following in order to require c++11 to run node-addon-api due to a dependency in node-addon-api to std::initializer_list.